### PR TITLE
40 dev gantt chart 2

### DIFF
--- a/src/todo-gantt/app/Livewire/Modals/TeamEdit.php
+++ b/src/todo-gantt/app/Livewire/Modals/TeamEdit.php
@@ -111,14 +111,24 @@ class TeamEdit extends Component
 
     if (!empty($this->mailaddress)) {
       $users = User::where('email', 'like', $this->mailaddress . '%')->get();
+      $users = $users->reject(function ($user) {
+        return $this->selectedTeam->users->contains($user);
+      });
     } else {
-      $users = collect(); // 空のコレクションを返す
+      $users = collect();
     }
     $this->users = $users;
   }
 
   public function addUserToTeam($user_id)
   {
+    $invatedUser = User::find($user_id);
+
+    if($invatedUser->teams->contains($this->selectedTeam->id)) {
+      session()->flash('flashWarning', 'ユーザーは既にこのチームに所属しています');
+      return redirect()->route('index');
+    }
+
     $this->selectedTeam->users()->attach($user_id);
     $this->mailaddress = '';
     $this->users = [];

--- a/src/todo-gantt/app/Models/Gantt.php
+++ b/src/todo-gantt/app/Models/Gantt.php
@@ -66,6 +66,7 @@ class Gantt extends Model
                 'custom_class' => "user-{$task->user_id}-task",
                 'user' => $project->name,
                 'user_id' => $project->user_id,
+                'completed' => $task->completed
             ];
         });
     }

--- a/src/todo-gantt/app/Models/Gantt.php
+++ b/src/todo-gantt/app/Models/Gantt.php
@@ -11,22 +11,23 @@ class Gantt extends Model
 {
     use HasFactory;
 
-    public static function getGanttData(User $user): array
-    {
-        $current_team = $user->selectedTeam;
-        
-        $projects = $current_team->projects()
-            ->with(['tasks' => function($query) {
-                $query->orderBy('start_date', 'asc');
-            }, 'user'])
-            ->orderByRaw('CASE WHEN user_id = ? THEN 0 ELSE 1 END', [$user->id])
-            ->orderByRaw('CASE WHEN user_id = ? THEN 0 ELSE user_id END ASC', [$user->id])
-            ->get();
+  public static function getGanttData(User $user): array
+  {
+    $current_team = $user->selectedTeam;
 
-        return $projects->map(function ($project) {
-            return static::processProject($project);
-        })->toArray();
-    }
+    $projects = $current_team->projects()
+      ->where('status_name', 'incomplete')
+      ->with(['tasks' => function ($query) {
+        $query->orderBy('start_date', 'asc');
+      }, 'user'])
+      ->orderByRaw('CASE WHEN user_id = ? THEN 0 ELSE 1 END', [$user->id])
+      ->orderByRaw('CASE WHEN user_id = ? THEN 0 ELSE user_id END ASC', [$user->id])
+      ->get();
+
+    return $projects->map(function ($project) {
+      return static::processProject($project);
+    })->toArray();
+  }
 
     private static function processProject($project): array
     {

--- a/src/todo-gantt/resources/js/frappgantt.js
+++ b/src/todo-gantt/resources/js/frappgantt.js
@@ -35,6 +35,16 @@ async function fetchGanttData() {
       throw new Error('Failed to fetch gantt data');
     }
 
+    if (ganttDatas.length === 0) {
+      const ganttContainer = document.getElementById('gantt');
+      const noTasksElement = document.createElement('div');
+      noTasksElement.textContent = '進行中のタスクはありません';
+      noTasksElement.style.padding = '20px';
+      noTasksElement.style.fontSize = '18px';
+      ganttContainer.appendChild(noTasksElement);
+      return;
+    }
+
     const tasks = extractTasks(ganttDatas);
     const gantt = new Gantt("#gantt", tasks);
 

--- a/src/todo-gantt/resources/js/frappgantt.js
+++ b/src/todo-gantt/resources/js/frappgantt.js
@@ -97,7 +97,7 @@ function extractTasks(ganttDatas) {
         end: endDate.toISOString().split('T')[0],
         user: project.user_name,
         user_id: project.user_id,
-        custom_class: `user-${project.user_id}-task task-bar`,
+        custom_class: `user-${project.user_id}-task task-bar ${task.completed ? 'completed-task' : ''}`,
         progress: 0,
       };
     }).filter(task => task !== null);

--- a/src/todo-gantt/resources/sass/frappgantt.scss
+++ b/src/todo-gantt/resources/sass/frappgantt.scss
@@ -24,4 +24,13 @@
   .task-bar {
     pointer-events: none;
   }
+
+  .completed-task {
+    text-decoration: line-through;
+    .bar {
+      fill: #777777 !important;
+    }
+  }
+
+
 }


### PR DESCRIPTION
# やること
ガントチャート画面の改善
  - [x] 自分のガントチャートを一番上にする
  - [x] プロジェクトのステータス「保留」「完了」では非表示にする
  - [x] タスクの「completed」フラグがtrueの場合、ガントチャートにも取消線を入れる

# その他の改善
- [x] [ユーザーをチーム招待するときの二重登録防止措置](https://github.com/ueni-tech/todo-gantt-app/pull/42/commits/6e7a90acb91be0cd18769b3af8ae535f935bfcc8)
  
# 画面サンプル
![image](https://github.com/user-attachments/assets/2da66b43-39c5-45ef-a8d7-c92d5abe6f21)  